### PR TITLE
Thread safe access from `use` block

### DIFF
--- a/src/main/kotlin/org/jire/strukt/Strukt.kt
+++ b/src/main/kotlin/org/jire/strukt/Strukt.kt
@@ -93,6 +93,11 @@ abstract class Strukt {
 	val members: MutableSet<StruktMember> = HashSet()
 	
 	/**
+	 * 
+	 */
+	val lock = Any()
+	
+	/**
 	 * Adjusts the view of this [Strukt] to match the specified [pointer].
 	 *
 	 * @param pointer The new reference pointer, which you can get from a [Strukt] allocation.
@@ -102,10 +107,12 @@ abstract class Strukt {
 	}
 	
 	inline fun <R> use(pointer: Long, block: Strukt.() -> R?) {
-		val previousPointer = this.pointer
-		this.pointer = pointer
-		block.invoke(this)
-		this.pointer = previousPointer
+		synchronized(lock) {
+			val previousPointer = this.pointer
+			this.pointer = pointer
+			block.invoke(this)
+			this.pointer = previousPointer
+		}
 	}
 	
 	operator fun Byte.provideDelegate(thisRef: Strukt, prop: KProperty<*>) = ByteMember(this@Strukt, this)


### PR DESCRIPTION
Currently strukts dont provide thread safe access, changing the pointer on one thread will also change the pointer on another.

I can think of two ways of doing this:
1. Storing the current pointer in a thread local reference (may be unintuitive if you change the pointer on one thread and it doesnt update on another?)
2. Adding a syncronised block to the `use` functionality. While this is slow, it will mean that as long as you always use the `use` block to access Strukts it will be thread safe.

What's your opinion?